### PR TITLE
Updated init and read_gps

### DIFF
--- a/Spaceport/23-24/Code/Teensy-Based Avionics/include/Sensor.h
+++ b/Spaceport/23-24/Code/Teensy-Based Avionics/include/Sensor.h
@@ -1,6 +1,7 @@
 #ifndef SENSOR_H
 #define SENSOR_H
 
+#include "RecordData.h"
 class Sensor {
 public:
     virtual ~Sensor() {}; //Virtual descructor. Very important

--- a/Spaceport/23-24/Code/Teensy-Based Avionics/src/MAX_M10S.cpp
+++ b/Spaceport/23-24/Code/Teensy-Based Avionics/src/MAX_M10S.cpp
@@ -1,11 +1,12 @@
 #include "MAX_M10S.h"
 
 /*
-Constructor for Max-M10s 
+Constructor for Max-M10s
 */
-MAX_M10S::MAX_M10S(uint8_t SCK, uint8_t SDA, uint8_t address) {
+MAX_M10S::MAX_M10S(uint8_t SCK, uint8_t SDA, uint8_t address)
+{
     SCK_pin = SCK;
-    SDA_pin = SDA; 
+    SDA_pin = SDA;
 
     first_fix = false;
     origin.x() = 38.987202;
@@ -27,58 +28,64 @@ MAX_M10S::MAX_M10S(uint8_t SCK, uint8_t SDA, uint8_t address) {
     fix_qual = -1;
 }
 
-//need to update origin some how
+// need to update origin some how
 
-bool MAX_M10S::initialize() {
+bool MAX_M10S::initialize()
+{
 
+    // myGNSS.enableDebugging(); // Uncomment this line to enable helpful debug messages on Serial
 
-    //myGNSS.enableDebugging(); // Uncomment this line to enable helpful debug messages on Serial
-    delay(25); // Wait for the serial port to initialize
     int count = 0;
-    while (m10s.begin() == false && count < 3) //Connect to the u-blox module using Wire port
+    while (m10s.begin() == false && count < 3) // Connect to the u-blox module using Wire port
     {
         // Serial.println(F("u-blox GNSS not detected at default I2C address. Retrying..."));
-        delay (1000);
-        count ++;
+        delay(1000);
+        count++;
     }
-    if(!m10s.begin()) return false;
+    if (!m10s.begin())
+        return false;
 
-    m10s.setI2COutput(COM_TYPE_UBX); //Set the I2C port to output UBX only (turn off NMEA noise)
-    
-    //myGNSS.saveConfigSelective(VAL_CFG_SUBSEC_IOPORT); //Optional: save (only) the communications port settings to flash and BBR
+    m10s.setI2COutput(COM_TYPE_UBX);            // Set the I2C port to output UBX only (turn off NMEA noise)
+    m10s.setNavigationFrequency(10);            // Set the update rate to 10Hz
+    m10s.setDynamicModel(DYN_MODEL_AIRBORNE4g); // Set the dynamic model to airborne with 4g acceleration
+    m10s.setAutoPVT(true);                      // Enable automatic PVT reports
+    m10s.saveConfiguration();                   // Save the current settings to flash and BBR
     return true;
 }
 
 /*
-used to update all instance variables 
+used to update all instance variables
 */
-void MAX_M10S::read_gps() {
-    if (!first_fix && m10s.getPVT() == true) {
-        first_fix = true;
-        origin.x() = m10s.getLatitude() / 10000000.0;
-        origin.y() = m10s.getLongitude() / 10000000.0;
-        origin.z() = m10s.getAltitude() / 1000.0;
-    }
-    altitude = m10s.getAltitude() / 1000.0; 
+void MAX_M10S::read_gps()
+{
+    if (!m10s.getPVT() || m10s.getInvalidLlh())
+        return; // See if new data is available
 
+    double time = millis() / 1000.0;
     pos.x() = m10s.getLatitude() / 10000000.0;
     pos.y() = m10s.getLongitude() / 10000000.0;
+    altitude = m10s.getAltitude() / 1000.0;
 
-    // updated before displacement and gps as the old values and new values are needed to get a 
+    if (!first_fix)
+    {
+        //recordLogData(INFO, "GPS has first fix"); //Log this data when the new data logging branch is merged.
+        first_fix = true;
+        origin.x() = pos.x();
+        origin.y() = pos.y();
+        origin.z() = altitude;
+    }
+
+    // updated before displacement and gps as the old values and new values are needed to get a
     // significant of a velocity
-    velocity.x() = ((pos.x() * 111139.0) - displacement.x()) / (millis() / 1000.0- gps_time);
-    velocity.y() = ((pos.y() * 111139.0) - displacement.y()) / (millis() / 1000.0 - gps_time);
-    velocity.z() = ((altitude / 1000.0) - displacement.z()) / (millis() / 1000.0 - gps_time); 
+    velocity.x() = ((pos.x() * 111139.0) - displacement.x()) / (time - gps_time);
+    velocity.y() = ((pos.y() * 111139.0) - displacement.y()) / (time - gps_time);
+    velocity.z() = ((altitude)-displacement.z()) / (time - gps_time);
 
-    displacement.x() = (m10s.getLatitude() / 10000000.0 - origin.x()) * 111139.0;
-    displacement.y() = (m10s.getLongitude() / 10000000.0- origin.y()) * 111139.0;
-    displacement.z() = ((m10s.getAltitude() / 1000.0) - origin.z());
+    displacement.x() = (pos.x() - origin.x()) * 111139.0;
+    displacement.y() = (pos.y() - origin.y()) * 111139.0;
+    displacement.z() = (altitude - origin.z());
 
-    gps_time = (millis() / 1000.0);
-    
-    irl_time.x() = m10s.getHour();
-    irl_time.y() = m10s.getMinute();
-    irl_time.z() = m10s.getSecond();
+    gps_time = time;
 
     fix_qual = m10s.getSIV();
 }
@@ -86,80 +93,81 @@ void MAX_M10S::read_gps() {
 /*
 return altitude in m
 */
-double MAX_M10S::get_alt() {
+double MAX_M10S::get_alt()
+{
     return altitude;
 }
 
 /*
-returns the lat and long of the rocket to the 7th sig fig 
+returns the lat and long of the rocket to the 7th sig fig
 */
-imu::Vector<2> MAX_M10S::get_pos() {
+imu::Vector<2> MAX_M10S::get_pos()
+{
     return pos;
-} 
+}
 
 /*
 return the velocity (meters per second)
 there probably issues with floating points
 */
-imu::Vector<3> MAX_M10S::get_velocity() {
+imu::Vector<3> MAX_M10S::get_velocity()
+{
     return velocity;
 }
 
 /*
 retern the displacement since the origin
-there is probably issues with floating point arithmetic 
+there is probably issues with floating point arithmetic
 */
-imu::Vector<3> MAX_M10S::get_displace() {
+imu::Vector<3> MAX_M10S::get_displace()
+{
     return displacement;
 }
 
 /*
 returns vector of orginal position in lat(deg), lat(deg), and alti(m)
 */
-imu::Vector<3> MAX_M10S::get_origin_pos() {
+imu::Vector<3> MAX_M10S::get_origin_pos()
+{
     return origin;
 }
 
-bool MAX_M10S::get_first_fix() {
+bool MAX_M10S::get_first_fix()
+{
     return first_fix;
 }
 
 /*
 time since in initialization in seconds
 */
-double MAX_M10S::get_gps_time() {
+double MAX_M10S::get_gps_time()
+{
     return gps_time;
-}
-
-/*
-returns the current hour, min, and sec 
-*/
-imu::Vector<3> MAX_M10S::get_irl_time() {   
-    return irl_time;
 }
 
 /*
 return the number of satellites to indicate quality of data
 */
-int MAX_M10S::get_fix_qual() {
+int MAX_M10S::get_fix_qual()
+{
     return fix_qual;
-}   
+}
 
-void * MAX_M10S::get_data() {
-    return (void *) &pos;
-
+void *MAX_M10S::get_data()
+{
+    return (void *)&pos;
 }
 
 const char *MAX_M10S::getcsvHeader()
-{                                                                                                                                                // incl G- for GPS
-    return "G-Lat (deg),G-Lon (deg),G-Alt (m),G-Speed (m/s),G-DispX (m),G-DispY (m),G-DispZ (m),G-Time (s),G-# of Sats,G-Real Time (hr/min/s),"; // trailing comma
+{                                                                                                                         // incl G- for GPS
+    return "G-Lat (deg),G-Lon (deg),G-Alt (m),G-Speed (m/s),G-DispX (m),G-DispY (m),G-DispZ (m),G-Time (s),G-# of Sats,"; // trailing comma
 }
 char *MAX_M10S::getdataString()
 {
     // See State.cpp::setdataString() for comments on what these numbers mean. 15 for GPS.
-    const int size = 15 * 2 + 12 * 5 + 10 * 1 + 10 + 10;
+    const int size = 15 * 2 + 12 * 5 + 10 * 1 + 10;
     char *data = new char[size];
-    snprintf(data, size, "%.10f,%.10f,%.2f,%.2f,%.2f,%.2f,%.2f,%.2f,%d,%.0f:%.0f:%.0f,", pos.x(), pos.y(), altitude, sqrt(pow(velocity.x(), 2) + pow(velocity.y(), 2) + pow(velocity.z(), 2)), displacement.x(), displacement.y(), displacement.z(), gps_time, fix_qual, irl_time.x(), irl_time.y(), irl_time.z()); // trailing comma
+    snprintf(data, size, "%.10f,%.10f,%.2f,%.2f,%.2f,%.2f,%.2f,%.2f,%d,", pos.x(), pos.y(), altitude, sqrt(pow(velocity.x(), 2) + pow(velocity.y(), 2) + pow(velocity.z(), 2)), displacement.x(), displacement.y(), displacement.z(), gps_time, fix_qual); // trailing comma
     return data;
 }
 char *MAX_M10S::getStaticDataString()

--- a/Spaceport/23-24/Code/Teensy-Based Avionics/src/MAX_M10S.h
+++ b/Spaceport/23-24/Code/Teensy-Based Avionics/src/MAX_M10S.h
@@ -31,7 +31,6 @@ public:
     imu::Vector<3> get_displace();
     double get_gps_time();
     bool get_first_fix();
-    imu::Vector<3> get_irl_time();
     imu::Vector<3> get_origin_pos();
     int get_fix_qual();
     void *get_data();

--- a/Spaceport/23-24/Code/Teensy-Based Avionics/src/State.cpp
+++ b/Spaceport/23-24/Code/Teensy-Based Avionics/src/State.cpp
@@ -290,8 +290,8 @@ char *State::getStateString()
 {
     delete[] stateString;
     stateString = new char[500]; // way oversized for right now.
-    snprintf(stateString, 500, "%.2f,%.2f,%s,%.2f,%.2f,%.2f,%.2f,%.2f,%.2f,%.2f,%.2f,%.2f,%.2f,%.2f,%.2f,%.2f,%.2f,%.2f",
-             timeAbsolute, timeSinceLaunch, STAGES[stageNumber], timeSincePreviousStage,
+    snprintf(stateString, 500, "%.2f,%.2f,%s,%.2f|%.2f,%.2f,%.2f|%.2f,%.2f,%.2f|%.2f,%.2f,%.2f|%.2f,%.2f,%.2f,%.2f,%.2f",
+             timeAbsolute / 1000.0, timeSinceLaunch / 1000.0, STAGES[stageNumber], timeSincePreviousStage / 1000.0,
              acceleration.x(), acceleration.y(), acceleration.z(),
              velocity.x(), velocity.y(), velocity.z(),
              position.x(), position.y(), position.z(),

--- a/Spaceport/23-24/Code/Teensy-Based Avionics/src/State.cpp
+++ b/Spaceport/23-24/Code/Teensy-Based Avionics/src/State.cpp
@@ -101,9 +101,9 @@ void State::determinetimeSinceLaunch()
 }
 void State::updateSensors()
 {
-    if (gps && millis() - lastGPSUpdate > 1500)
+    if (gps)
     {
-        gps->read_gps();
+        gps->read_gps();//should no longer be as blocking as it was and should have new data every 100ms.
         lastGPSUpdate = millis();
     }
     if (baro)

--- a/Spaceport/23-24/Code/Teensy-Based Avionics/src/main.cpp
+++ b/Spaceport/23-24/Code/Teensy-Based Avionics/src/main.cpp
@@ -27,13 +27,12 @@ void setup()
     digitalWrite(LED_BUILTIN, LOW);
 
 
-    // Serial.begin(9600);
+    Serial.begin(9600);
     // while (!Serial);
 
     
     computer.setBaro(&bmp);
-    // computer.addGPS(&gps);
-    // computer.addRTC(&rtc);
+    computer.setGPS(&gps);
     computer.setIMU(&bno);
 
     computer.init();
@@ -66,7 +65,9 @@ void loop() {
     
     computer.updateState();
 
-    Serial.println(computer.getStateString());
+    //Serial.println(computer.getStateString());
+    Serial.println(computer.getGPS()->get_fix_qual());
+    Serial.println(computer.getGPS()->getdataString());
     recordData(computer.getdataString(), computer.getStageNum());
-    delay(50);
+    delay(100);
 }


### PR DESCRIPTION
## Summary:
Reduces the number of calls to the M10s chip over I2C and attempts to help reduce the time spent fetching those calls. Needs to be tested.


## Changes:

### Major:
- Updated refresh rate of GPS to 10 hz. (from 1hz) This is a test but everything indicates it should work.

### Minor:
- Let the module automatically update and buffer it's PVT data to prevent blocking calls to the chip when fetching data. Experimental fix, needs testing.
- Set the dynamic mode to airborne 4g (fixes #41).
- Added `RecordData.h` to `Sensor.h` in anticipation of the logging capabilities being added.
- Slightly reworked how it gets its first fix. Needs to be tested.

## Bug Fixes:
None of note.