### PR TITLE
Better handling of sensors

### DIFF
--- a/Spaceport/23-24/Code/Teensy-Based Avionics/cppcheck-suppressions.txt
+++ b/Spaceport/23-24/Code/Teensy-Based Avionics/cppcheck-suppressions.txt
@@ -1,0 +1,16 @@
+//A list of warnings and errors that cppcheck should not look for.
+//format for suppressions are [errorId]:[file]:[line#]
+//file and line# are optional, and errorId and file may include * or ? wildcards.
+
+//everything in .pio
+*:*/.pio/*
+
+shadowVariable:*
+
+*:*/lib/RadioHead/*
+
+//This seems to be a bug with cppcheck where everything is "unused"
+unusedFunction:*
+
+//While technically faster, the strange format is unintuitive for new people and would be more trouble than it's worth.
+useInitializationList:*

--- a/Spaceport/23-24/Code/Teensy-Based Avionics/include/GPS.h
+++ b/Spaceport/23-24/Code/Teensy-Based Avionics/include/GPS.h
@@ -18,6 +18,7 @@ public:
     virtual char *getTimeOfDay() = 0;
     virtual int getFixQual() = 0;
     virtual double getHeading() = 0;
+    virtual bool getHasFirstFix() = 0;
 
     virtual const char *getTypeString() override { return "GPS"; }
     virtual SensorType getType() override { return GPS_; }

--- a/Spaceport/23-24/Code/Teensy-Based Avionics/include/RTC.h
+++ b/Spaceport/23-24/Code/Teensy-Based Avionics/include/RTC.h
@@ -18,7 +18,6 @@ public:
     virtual DateTime setLaunchTime() = 0;
     virtual DateTime getPowerOnTime() = 0;
     virtual DateTime getCurrentTime() = 0;
-    virtual void * getData() = 0;
     virtual SensorType getType() override { return RTC_; }
     virtual const char *getTypeString() override { return "RTC"; }
 };

--- a/Spaceport/23-24/Code/Teensy-Based Avionics/include/Sensor.h
+++ b/Spaceport/23-24/Code/Teensy-Based Avionics/include/Sensor.h
@@ -3,8 +3,8 @@
 
 #include "RecordData.h"
 
-
-enum SensorType {
+enum SensorType
+{
     BAROMETER_,
     GPS_,
     IMU_,
@@ -13,27 +13,30 @@ enum SensorType {
     RTC_,
     UNKNOWN_
 };
-class Sensor {
+class Sensor
+{
 public:
-    virtual ~Sensor() {}; //Virtual descructor. Very important
+    virtual ~Sensor(){}; // Virtual descructor. Very important
     // Sets up the sensor and stores any critical parameters
-    virtual bool initialize() = 0; 
-    // a generic function that returns a pointer to the sensor's most import data value
-    //deprecate this function?
-    virtual void * getData() = 0;
+    virtual bool initialize() = 0;
     // gives the names of the columns which transient data will be stored under, in a comma separated string
-    virtual const char* getCsvHeader() = 0;
+    virtual const char *getCsvHeader() = 0;
     // gives the data values of the variables said to be stored by the header, in the same order, in a comma separated string
-    virtual char* getDataString() = 0;//HEAP ALLOCATED
+    virtual char *getDataString() = 0; // HEAP ALLOCATED
     // gives a string which includes all the sensor's static/initialization data. This will be in the format of dataName:dataValue, with each pair separated by a newline (\n)
-    virtual char* getStaticDataString() = 0;//HEAP ALLOCATED
+    virtual char *getStaticDataString() = 0; // HEAP ALLOCATED
 
-    virtual SensorType getType() = 0;//Returns the type of the sensor
-    virtual const char* getTypeString() = 0;//Returns the type of the sensor as a string
-    virtual const char* getName() = 0;//Returns the name of the sensor
+    virtual SensorType getType() = 0;        // Returns the type of the sensor
+    virtual const char *getTypeString() = 0; // Returns the type of the sensor as a string
+    virtual const char *getName() = 0;       // Returns the name of the sensor
 
-    virtual void update() = 0;//Updates the sensor's fields by querying the sensor for new data
+    virtual void update() = 0; // Updates the sensor's fields by querying the sensor for new data
+
+    virtual bool isInitialized() { return initialized; } // Returns whether the sensor has been initialized or not
+
+    virtual explicit operator bool() const { return initialized; } // Returns whether the sensor has been initialized or not
+protected:
+    bool initialized = false;
 };
 
-
-#endif //SENSOR_H
+#endif // SENSOR_H

--- a/Spaceport/23-24/Code/Teensy-Based Avionics/lib/RecordData/RecordData.cpp
+++ b/Spaceport/23-24/Code/Teensy-Based Avionics/lib/RecordData/RecordData.cpp
@@ -49,6 +49,9 @@ void recordLogData(double timeStamp, LogType type, const char *data, Dest dest)
         }
         else if (ram->isReady()) // while in flight, print to PSRAM for later dumping to SD card.
         {
+            // if (!Serial){
+            //     Serial.begin(9600);
+            // }
             ram->print(logPrefix, false);
             ram->println(data, false);
         }

--- a/Spaceport/23-24/Code/Teensy-Based Avionics/lib/RecordData/RecordData.cpp
+++ b/Spaceport/23-24/Code/Teensy-Based Avionics/lib/RecordData/RecordData.cpp
@@ -32,6 +32,9 @@ void recordLogData(double timeStamp, LogType type, const char *data, Dest dest)
 
     if (dest == BOTH || dest == TO_USB)
     {
+        // if (!Serial){
+        //     Serial.begin(9600);
+        // }
         Serial.print(logPrefix);
         Serial.println(data);
     }
@@ -49,9 +52,6 @@ void recordLogData(double timeStamp, LogType type, const char *data, Dest dest)
         }
         else if (ram->isReady()) // while in flight, print to PSRAM for later dumping to SD card.
         {
-            // if (!Serial){
-            //     Serial.begin(9600);
-            // }
             ram->print(logPrefix, false);
             ram->println(data, false);
         }

--- a/Spaceport/23-24/Code/Teensy-Based Avionics/lib/RecordData/RecordData.cpp
+++ b/Spaceport/23-24/Code/Teensy-Based Avionics/lib/RecordData/RecordData.cpp
@@ -32,11 +32,8 @@ void recordLogData(double timeStamp, LogType type, const char *data, Dest dest)
 
     if (dest == BOTH || dest == TO_USB)
     {
-        // if (!Serial)
-        //     Serial.begin(9600);
-
-        // Serial.print(logPrefix);
-        // Serial.println(data);
+        Serial.print(logPrefix);
+        Serial.println(data);
     }
     if ((dest == BOTH || dest == TO_FILE) && isSDReady())
     {

--- a/Spaceport/23-24/Code/Teensy-Based Avionics/lib/RecordData/psram.cpp
+++ b/Spaceport/23-24/Code/Teensy-Based Avionics/lib/RecordData/psram.cpp
@@ -14,7 +14,7 @@ PSRAM::PSRAM()
 bool PSRAM::init()
 {
     uint8_t size = external_psram_size;
-    memBegin = cursorStart = (char *)(0x70000000);
+    memBegin = cursorStart = reinterpret_cast<char *>(0x70000000);
     memEnd = cursorEnd = memBegin + (size * 1048576);
 
     if (size > 0)
@@ -82,7 +82,7 @@ bool PSRAM::dumpLogData()
 
     char buffer[2048]; // large buffer but the Teensy should be able to handle it. Buffer should be a multiple of 512 for SD card efficiency.
     char *writeCursor = memEnd;
-    int i = 0;
+    int i;
     logFile = sd.open(logFileName, FILE_WRITE);
 
     if (!logFile){

--- a/Spaceport/23-24/Code/Teensy-Based Avionics/platformio.ini
+++ b/Spaceport/23-24/Code/Teensy-Based Avionics/platformio.ini
@@ -24,6 +24,9 @@ lib_deps =
 	adafruit/Adafruit BNO055@^1.6.3
 	adafruit/Adafruit Unified Sensor@^1.1.14
 	sparkfun/SparkFun u-blox GNSS v3@^3.0.16
+check_src_filters = -<*> +<src/*> +<include/*> +<lib/*> -<lib/RadioHead>
+check_flags =
+	cppcheck: --suppressions-list=cppcheck-suppressions.txt -j 12
 
 [env:arduino_uno]
 platform = atmelavr
@@ -39,6 +42,9 @@ lib_deps =
 	adafruit/Adafruit BNO055@^1.6.3
 	adafruit/Adafruit Unified Sensor@^1.1.14
 	sparkfun/SparkFun u-blox GNSS v3@^3.0.16
+check_src_filters = -<*> +<src/*> +<include/*> +<lib/*> -<lib/RadioHead>
+check_flags =
+	cppcheck: --suppressions-list=cppcheck-suppressions.txt -j 12
 
 [env:teensy41_TEST_STATE]
 platform = teensy
@@ -54,3 +60,8 @@ lib_deps =
 	adafruit/Adafruit BNO055@^1.6.3
 	adafruit/Adafruit Unified Sensor@^1.1.14
 	sparkfun/SparkFun u-blox GNSS v3@^3.0.16
+check_src_filters = -<*> +<src/*> +<include/*> +<lib/*> -<lib/RadioHead>
+check_flags =
+	cppcheck: --suppressions-list=cppcheck-suppressions.txt -j 12
+
+

--- a/Spaceport/23-24/Code/Teensy-Based Avionics/src/BMP390.cpp
+++ b/Spaceport/23-24/Code/Teensy-Based Avionics/src/BMP390.cpp
@@ -7,7 +7,10 @@ BMP390::BMP390(uint8_t SCK, uint8_t SDA)
 {
     SCKPin = SCK;
     SDAPin = SDA;
-
+    groundPressure = 0;
+    pressure = 0;
+    temp = 0;
+    altitude = 0;
 }
 
 bool BMP390::initialize()

--- a/Spaceport/23-24/Code/Teensy-Based Avionics/src/BMP390.cpp
+++ b/Spaceport/23-24/Code/Teensy-Based Avionics/src/BMP390.cpp
@@ -7,7 +7,7 @@ BMP390::BMP390(uint8_t SCK, uint8_t SDA)
 {
     SCKPin = SCK;
     SDAPin = SDA;
-    
+
 }
 
 bool BMP390::initialize()
@@ -88,7 +88,7 @@ char *BMP390::getDataString()
     // float x3
     const int size = 12 * 3 + 3;
     char *data = new char[size];
-    snprintf(data, size, "%.2f,%.2f,%.2f,", pressure, temp, altitude); // trailing comma
+    snprintf(data, size, "%.2f,%.2f,%.2f,", pressure, temp, getRelAltFt()); // trailing comma
     return data;
 }
 

--- a/Spaceport/23-24/Code/Teensy-Based Avionics/src/BMP390.cpp
+++ b/Spaceport/23-24/Code/Teensy-Based Avionics/src/BMP390.cpp
@@ -5,18 +5,17 @@ Construtor for the BMP390 class, pass in the pin numbers for each of the I2C pin
 */
 BMP390::BMP390(uint8_t SCK, uint8_t SDA)
 {
-
     SCKPin = SCK;
     SDAPin = SDA;
+    
 }
 
 bool BMP390::initialize()
 {
-
     if (!bmp.begin_I2C())
     { // hardware I2C mode, can pass in address & alt Wire
         // Serial.println("Could not find a valid BMP390 sensor, check wiring!");
-        return false;
+        return initialized = false;
     }
 
     delay(1000);
@@ -39,14 +38,16 @@ bool BMP390::initialize()
         delay(25);
     }
     groundPressure = (startPressure / 100.0) / 100.0; // hPa
-    return true;
+    return initialized = true;
 }
+
 void BMP390::update()
 {
-    pressure = bmp.readPressure() / 100.0; // hPa
-    temp = bmp.readTemperature();          // C
+    pressure = bmp.readPressure() / 100.0;       // hPa
+    temp = bmp.readTemperature();                // C
     altitude = bmp.readAltitude(groundPressure); // m
 }
+
 double BMP390::getPressure()
 {
     return pressure;
@@ -77,13 +78,8 @@ double BMP390::getRelAltFt()
     return altitude * 3.28084;
 }
 
-void *BMP390::getData()
-{
-    return (void *)&altitude;
-}
-
 const char *BMP390::getCsvHeader()
-{ // incl  B- to indicate Barometer data  vvvv Why is this in ft and not m?
+{                                                 // incl  B- to indicate Barometer data  vvvv Why is this in ft and not m?
     return "B-Pres (hPa),B-Temp (C),B-Alt (ft),"; // trailing commas are very important
 }
 
@@ -92,7 +88,7 @@ char *BMP390::getDataString()
     // float x3
     const int size = 12 * 3 + 3;
     char *data = new char[size];
-    snprintf(data, size, "%.2f,%.2f,%.2f,", pressure, temp, altitude);//trailing comma
+    snprintf(data, size, "%.2f,%.2f,%.2f,", pressure, temp, altitude); // trailing comma
     return data;
 }
 

--- a/Spaceport/23-24/Code/Teensy-Based Avionics/src/BMP390.h
+++ b/Spaceport/23-24/Code/Teensy-Based Avionics/src/BMP390.h
@@ -20,12 +20,12 @@ private:
 
 public:
     BMP390(uint8_t SCK, uint8_t SDA);
-    double getPressure();
-    double getTemp();
-    double getTempF();
-    double getPressureAtm();
-    double getRelAltFt();
-    double getRelAltM();
+    double getPressure() override;
+    double getTemp() override;
+    double getTempF() override;
+    double getPressureAtm() override;
+    double getRelAltFt() override;
+    double getRelAltM() override;
     bool initialize() override;
     const char *getCsvHeader() override;
     char *getDataString() override;

--- a/Spaceport/23-24/Code/Teensy-Based Avionics/src/BMP390.h
+++ b/Spaceport/23-24/Code/Teensy-Based Avionics/src/BMP390.h
@@ -26,7 +26,6 @@ public:
     double getPressureAtm();
     double getRelAltFt();
     double getRelAltM();
-    void *getData();
     bool initialize() override;
     const char *getCsvHeader() override;
     char *getDataString() override;

--- a/Spaceport/23-24/Code/Teensy-Based Avionics/src/BNO055.cpp
+++ b/Spaceport/23-24/Code/Teensy-Based Avionics/src/BNO055.cpp
@@ -10,13 +10,14 @@ bool BNO055::initialize()
 {
     if (!bno.begin())
     {
-        return false;
+        return initialized = false;
     }
     bno.setExtCrystalUse(true);
 
     initialMagField = bno.getVector(Adafruit_BNO055::VECTOR_MAGNETOMETER);
-    return true;
+    return initialized = true;
 }
+
 void BNO055::update()
 {
     orientation = bno.getQuat();
@@ -24,6 +25,7 @@ void BNO055::update()
     orientationEuler = bno.getVector(Adafruit_BNO055::VECTOR_EULER);
     magnetometer = bno.getVector(Adafruit_BNO055::VECTOR_MAGNETOMETER);
 }
+
 void BNO055::calibrate_bno()
 {
     uint8_t system, gyro, accel, mag, i = 0;
@@ -65,12 +67,6 @@ imu::Vector<3> convert_to_euler(imu::Quaternion orientation)
     // reverse the vector, since it returns in z, y, x
     euler = imu::Vector<3>(euler.x(), euler.y(), euler.z());
     return euler;
-}
-
-// will give back a pointer to a linear acceleration vector
-void *BNO055::getData()
-{
-    return (void *)&accelerationVec;
 }
 
 const char *BNO055::getCsvHeader()

--- a/Spaceport/23-24/Code/Teensy-Based Avionics/src/BNO055.cpp
+++ b/Spaceport/23-24/Code/Teensy-Based Avionics/src/BNO055.cpp
@@ -26,7 +26,7 @@ void BNO055::update()
     magnetometer = bno.getVector(Adafruit_BNO055::VECTOR_MAGNETOMETER);
 }
 
-void BNO055::calibrate_bno()
+void BNO055::calibrateBno()
 {
     uint8_t system, gyro, accel, mag, i = 0;
     while ((system != 3) || (gyro != 3) || (accel != 3) || (mag != 3))
@@ -61,7 +61,7 @@ imu::Vector<3> BNO055::getMagnetometer()
     return magnetometer;
 }
 
-imu::Vector<3> convert_to_euler(imu::Quaternion orientation)
+imu::Vector<3> convertToEuler(const imu::Quaternion &orientation)
 {
     imu::Vector<3> euler = orientation.toEuler();
     // reverse the vector, since it returns in z, y, x

--- a/Spaceport/23-24/Code/Teensy-Based Avionics/src/BNO055.h
+++ b/Spaceport/23-24/Code/Teensy-Based Avionics/src/BNO055.h
@@ -16,15 +16,15 @@ private:
 
 public:
     BNO055(uint8_t SCK, uint8_t SDA);
-    void calibrate_bno();//unused?
-    imu::Quaternion getOrientation();
-    // gives linear_acceleration in m/s/s, which excludes gravity
-    imu::Vector<3> getAcceleration();
-    imu::Vector<3> getOrientationEuler();
+    void calibrateBno();
+    imu::Quaternion getOrientation() override;
+    // gives linearAcceleration in m/s/s, which excludes gravity
+    imu::Vector<3> getAcceleration() override;
+    imu::Vector<3> getOrientationEuler() override;
     // values in uT, micro Teslas
-    imu::Vector<3> getMagnetometer();
+    imu::Vector<3> getMagnetometer() override;
     // gives it in rotations about the x, y, z (yaw, pitch, roll) axes
-    imu::Vector<3> convert_to_euler(imu::Quaternion orientation);//unused?
+    imu::Vector<3> convertToEuler(const imu::Quaternion &orientation);
     bool initialize() override;
     const char *getCsvHeader() override;
     char *getDataString() override;

--- a/Spaceport/23-24/Code/Teensy-Based Avionics/src/BNO055.h
+++ b/Spaceport/23-24/Code/Teensy-Based Avionics/src/BNO055.h
@@ -16,7 +16,7 @@ private:
 
 public:
     BNO055(uint8_t SCK, uint8_t SDA);
-    void calibrate_bno();
+    void calibrate_bno();//unused?
     imu::Quaternion getOrientation();
     // gives linear_acceleration in m/s/s, which excludes gravity
     imu::Vector<3> getAcceleration();
@@ -24,8 +24,7 @@ public:
     // values in uT, micro Teslas
     imu::Vector<3> getMagnetometer();
     // gives it in rotations about the x, y, z (yaw, pitch, roll) axes
-    imu::Vector<3> convert_to_euler(imu::Quaternion orientation);
-    void *getData();
+    imu::Vector<3> convert_to_euler(imu::Quaternion orientation);//unused?
     bool initialize() override;
     const char *getCsvHeader() override;
     char *getDataString() override;

--- a/Spaceport/23-24/Code/Teensy-Based Avionics/src/DS3231.cpp
+++ b/Spaceport/23-24/Code/Teensy-Based Avionics/src/DS3231.cpp
@@ -50,10 +50,6 @@ DateTime DS3231::setLaunchTime() {
     return launchTime;
 }
 
-void * DS3231::getData() { //sec since launch, cast to void pointer
-    return ((void *)(millis()));
-}
-
 const char *DS3231::getCsvHeader()
 {
     return "R-CurTime,R-Time Since Launch,"; // trailing comma

--- a/Spaceport/23-24/Code/Teensy-Based Avionics/src/DS3231.h
+++ b/Spaceport/23-24/Code/Teensy-Based Avionics/src/DS3231.h
@@ -21,7 +21,6 @@ public:
     DateTime getPowerOnTime();
     DateTime getCurrentTime();
     DateTime setLaunchTime();
-    void *getData();
     bool initialize() override;
     const char *getCsvHeader() override;
     char *getDataString() override;

--- a/Spaceport/23-24/Code/Teensy-Based Avionics/src/DS3231.h
+++ b/Spaceport/23-24/Code/Teensy-Based Avionics/src/DS3231.h
@@ -15,12 +15,12 @@ private:
 public:
     DS3231(); // constructor
     void onLaunch();
-    imu::Vector<2> getTimeOn(); // ms
-    imu::Vector<2> getTimeSinceLaunch(); // ms
-    DateTime getLaunchTime(); 
-    DateTime getPowerOnTime();
-    DateTime getCurrentTime();
-    DateTime setLaunchTime();
+    imu::Vector<2> getTimeOn() override; // ms
+    imu::Vector<2> getTimeSinceLaunch() override; // ms
+    DateTime getLaunchTime() override; 
+    DateTime getPowerOnTime() override;
+    DateTime getCurrentTime() override;
+    DateTime setLaunchTime() override;
     bool initialize() override;
     const char *getCsvHeader() override;
     char *getDataString() override;

--- a/Spaceport/23-24/Code/Teensy-Based Avionics/src/MAX_M10S.cpp
+++ b/Spaceport/23-24/Code/Teensy-Based Avionics/src/MAX_M10S.cpp
@@ -25,6 +25,12 @@ MAX_M10S::MAX_M10S(uint8_t SCK, uint8_t SDA, uint8_t address)
     irlTime.y() = 0;
     irlTime.z() = 0;
     fixQual = 0;
+    heading = 0;
+    hr = 0;
+    min = 0;
+    sec = 0;
+    time = 0;
+    strcpy(gpsTime, "00:00:00");
 }
 
 // need to update origin some how

--- a/Spaceport/23-24/Code/Teensy-Based Avionics/src/MAX_M10S.h
+++ b/Spaceport/23-24/Code/Teensy-Based Avionics/src/MAX_M10S.h
@@ -33,11 +33,9 @@ public:
     imu::Vector<2> getPos();
     imu::Vector<3> getDisplace();
     char *getTimeOfDay();
-    bool get_first_fix();
     imu::Vector<3> getOriginPos();
     int getFixQual();
     double getHeading();
-    void *getData();
 
     bool initialize() override;
     const char *getCsvHeader() override;
@@ -45,6 +43,7 @@ public:
     char *getStaticDataString() override;
     const char *getName() override;
     void update() override;
+    bool getHasFirstFix() override;
 };
 
 #endif // MAX_M10S_H

--- a/Spaceport/23-24/Code/Teensy-Based Avionics/src/MAX_M10S.h
+++ b/Spaceport/23-24/Code/Teensy-Based Avionics/src/MAX_M10S.h
@@ -28,14 +28,14 @@ private:
 
 public:
     MAX_M10S(uint8_t SCK, uint8_t SDA, uint8_t address);
-    double getAlt();
-    imu::Vector<3> getVelocity();
-    imu::Vector<2> getPos();
-    imu::Vector<3> getDisplace();
-    char *getTimeOfDay();
-    imu::Vector<3> getOriginPos();
-    int getFixQual();
-    double getHeading();
+    double getAlt() override;
+    imu::Vector<3> getVelocity() override;
+    imu::Vector<2> getPos() override;
+    imu::Vector<3> getDisplace() override;
+    char *getTimeOfDay() override;
+    imu::Vector<3> getOriginPos() override;
+    int getFixQual() override;
+    double getHeading() override;
 
     bool initialize() override;
     const char *getCsvHeader() override;

--- a/Spaceport/23-24/Code/Teensy-Based Avionics/src/State.cpp
+++ b/Spaceport/23-24/Code/Teensy-Based Avionics/src/State.cpp
@@ -1,7 +1,6 @@
 #include "State.h"
-
 #pragma region Constructor and Destructor
-State::State(bool useKalmanFilter)
+State::State(bool useKalmanFilter, bool stateRecordsOwnFlightData)
 {
     timeAbsolute = millis();
     timePreviousStage = 0;
@@ -28,7 +27,7 @@ State::State(bool useKalmanFilter)
     csvHeader = nullptr;
 
     numSensors = 0;
-    recordOwnFlightData = true;
+    recordOwnFlightData = stateRecordsOwnFlightData;
     for (int i = 0; i < NUM_MAX_SENSORS; i++)
         sensors[i] = nullptr;
 
@@ -57,10 +56,8 @@ State::~State()
 
 #pragma endregion
 
-bool State::init(bool stateRecordsOwnFlightData)
+bool State::init()
 {
-
-    recordOwnFlightData = stateRecordsOwnFlightData;
     char *logData = new char[100];
     int good = 0, tryNumSensors = 0;
     for (int i = 0; i < NUM_MAX_SENSORS; i++)
@@ -84,8 +81,14 @@ bool State::init(bool stateRecordsOwnFlightData)
                 strcat(logData, sensors[i]->getName());
                 strcat(logData, "] failed to initialize.");
                 recordLogData(ERROR, logData);
-                sensors[i] = nullptr;
             }
+        }
+        else
+        {
+            strcpy(logData, "Sensor [");
+            strcat(logData, SENSOR_NAMES[i]);
+            strcat(logData, "] was not added via addSensor().");
+            recordLogData(ERROR, logData);
         }
     }
     if (radio)
@@ -97,7 +100,7 @@ bool State::init(bool stateRecordsOwnFlightData)
     setCsvHeader();
     if (useKF)
     {
-        initKF(gps ? 1 : 0, baro ? 1 : 0, imu ? 1 : 0);
+        initKF();
     }
     return good == tryNumSensors;
 }
@@ -106,47 +109,56 @@ void State::updateSensors()
 {
     for (int i = 0; i < NUM_MAX_SENSORS; i++)
     {
-        if (sensors[i])
+        if (sensorOK(sensors[i]))
+        { // not nullptr and initialized
             sensors[i]->update();
-        Wire.beginTransmission(0x42);
-        byte b = Wire.endTransmission();
-        if (b != 0x00)
-        {
-            Wire.end();
-            Wire.begin();
-            recordLogData(ERROR, "I2C Error");
-            sensors[i]->update();
-            delay(10);
-            sensors[i]->update();
+            Wire.beginTransmission(0x42);//random address for testing the i2c bus
+            byte b = Wire.endTransmission();
+            if (b != 0x00)
+            {
+                Wire.end();
+                Wire.begin();
+                recordLogData(ERROR, "I2C Error");
+                sensors[i]->update();
+                delay(10);
+                sensors[i]->update();
+            }
         }
     }
 }
 
 void State::updateState()
-{    
-    if(timeSinceLaunch > 0 && timeSinceLaunch < 2 )
+{
+    if (timeSinceLaunch > 0 && timeSinceLaunch < 2)
         digitalWrite(33, HIGH);
-    else{
+    else
         digitalWrite(33, LOW);
-    }
+
     if (stageNumber > 4 && landingCounter > 50) // if landed and waited 5 seconds, don't update sensors.
         return;
+    
     updateSensors();
-    if (useKF && (*gps)->getFixQual() > 5 && stageNumber > 0)
+    if (useKF && sensorOK(gps) && gps->getHasFirstFix() && stageNumber > 0)
     {
-        GPS *gps = *this->gps;
-        Barometer *baro = *this->baro;
-        IMU *imu = *this->imu;
         // gps x y z barometer z
         measurements[0] = gps->getDisplace().x();
         measurements[1] = gps->getDisplace().y();
         measurements[2] = gps->getDisplace().z();
-        measurements[3] = baro->getRelAltM();
+        measurements[3] = sensorOK(baro) ? baro->getRelAltM() : 0;
         // imu x y z
-        inputs[0] = imu->getAcceleration().x();
-        inputs[1] = imu->getAcceleration().y();
-        inputs[2] = imu->getAcceleration().z(); // remove g
-        akf::updateFilter(kfilter, timeAbsolute, gps ? 1 : 0, baro ? 1 : 0, imu ? 1 : 0, measurements, inputs, &predictions);
+        if(sensorOK(imu))
+        {
+            inputs[0] = imu->getAcceleration().x();
+            inputs[1] = imu->getAcceleration().y();
+            inputs[2] = imu->getAcceleration().z();
+        }
+        else//If this is false, the filter is basically useless as far as I understand.
+        {
+            inputs[0] = 0;
+            inputs[1] = 0;
+            inputs[2] = 0;
+        }
+        akf::updateFilter(kfilter, timeAbsolute, sensorOK(gps) ? 1 : 0, sensorOK(baro) ? 1 : 0, sensorOK(imu) ? 1 : 0, measurements, inputs, &predictions);
         // time, pos x, y, z, vel x, y, z, acc x, y, z
         // ignore time return value.
         position.x() = predictions[1];
@@ -159,42 +171,43 @@ void State::updateState()
         acceleration.y() = predictions[8];
         acceleration.z() = predictions[9];
 
-        orientation = imu->getOrientation();
+        orientation = sensorOK(imu) ? imu->getOrientation() : imu::Quaternion(0, 0, 0, 1);
 
-        if (baro)
+        if (sensorOK(baro))
         {
-            baroVelocity = ((baro)->getRelAltM() - baroOldAltitude) / (millis() / 1000.0 - timeAbsolute);
-            baroOldAltitude = (baro)->getRelAltM();
+            baroVelocity = (baro->getRelAltM() - baroOldAltitude) / (millis() / 1000.0 - timeAbsolute);
+            baroOldAltitude = baro->getRelAltM();
         }
-
     }
     else
     {
-        if (*gps)
+        if (sensorOK(gps))
         {
-            position = imu::Vector<3>((*gps)->getDisplace().x(), (*gps)->getDisplace().y(), (*gps)->getAlt());
-            velocity = (*gps)->getVelocity();
-            heading_angle = (*gps)->getHeading();
+            position = imu::Vector<3>(gps->getDisplace().x(), gps->getDisplace().y(), gps->getAlt());
+            velocity = gps->getVelocity();
+            heading_angle = gps->getHeading();
         }
-        if (*baro)
+        if (sensorOK(baro))
         {
-            velocity.z() = ((*baro)->getRelAltM() - position.z()) / (millis() / 1000.0 - timeAbsolute);
-            position.z() = (*baro)->getRelAltM();
-            baroVelocity = ((*baro)->getRelAltM() - baroOldAltitude) / (millis() / 1000.0 - timeAbsolute);
-            baroOldAltitude = (*baro)->getRelAltM();
+            velocity.z() = (baro->getRelAltM() - position.z()) / (millis() / 1000.0 - timeAbsolute);
+            position.z() = baro->getRelAltM();
+            baroVelocity = (baro->getRelAltM() - baroOldAltitude) / (millis() / 1000.0 - timeAbsolute);
+            baroOldAltitude = baro->getRelAltM();
         }
-        if (*imu)
+        if (sensorOK(imu))
         {
-            acceleration = (*imu)->getAcceleration();
-            orientation = (*imu)->getOrientation();
+            acceleration = imu->getAcceleration();
+            orientation = imu->getOrientation();
         }
     }
     timeAbsolute = millis() / 1000.0;
-    timeSinceLaunch = timeAbsolute - timeOfLaunch;
     determineAccelerationMagnitude();
     determineStage();
+    if(stageNumber > 0)
+        timeSincePreviousStage = timeAbsolute - timePreviousStage;
     if (stageNumber < 3)
         apogee = position.z();
+
     // backup case to dump data (25 minutes)
     if (stageNumber > 0 && timeSinceLaunch > 1500 && stageNumber < 5)
     {
@@ -237,13 +250,13 @@ char *State::getStateString()
 {
     delete[] stateString;
     stateString = new char[500]; // way oversized for right now.
-    snprintf(stateString, 500, "%.2f,%.2f,%s,%.2f|%.2f,%.2f,%.2f|%.2f,%.2f,%.2f|%.7f,%.7f,%.2f|%.2f,%.2f,%.2f,%.2f|%d",
+    snprintf(stateString, 500, "%.2f,%.2f,%s,%.2f|%.2f,%.2f,%.2f|%.2f,%.2f,%.2f|%.7f,%.7f,%.2f|%.2f,%.2f,%.2f,%.2f|%.2f",
              timeAbsolute, timeSinceLaunch, STAGES[stageNumber], timeSincePreviousStage,
              acceleration.x(), acceleration.y(), acceleration.z(),
              velocity.x(), velocity.y(), velocity.z(),
              position.x(), position.y(), position.z(),
              orientation.x(), orientation.y(), orientation.z(), orientation.w(),
-             (*gps)->getFixQual());
+             apogee);
     return stateString;
 }
 
@@ -252,53 +265,74 @@ char *State::getCsvHeader() { return csvHeader; }
 int State::getStageNum() { return stageNumber; }
 
 #pragma region Getters and Setters for Sensors
+
 void State::setRadio(Radio *r) { radio = r; }
 Radio *State::getRadio() { return radio; }
-bool State::addSensor(Sensor *sensor)
+bool State::addSensor(Sensor *sensor, int sensorNum)
 {
+    int modifiedNum = sensorNum;
     for (int i = 0; i < NUM_MAX_SENSORS; i++)
     {
-        if (sensors[i] == nullptr)
+        if (SENSOR_ORDER[i] == sensor->getType() && --modifiedNum == 0)
         {
             sensors[i] = sensor;
-            return applySensorType(i);
+            return applySensorType(i, sensorNum);
         }
     }
     return false;
 }
 
-Sensor *State::getSensor(SensorType type)
+Sensor *State::getSensor(SensorType type, int sensorNum)
 {
     for (int i = 0; i < NUM_MAX_SENSORS; i++)
     {
-        if (sensors[i] && sensors[i]->getType() == type)
+        if (SENSOR_ORDER[i] == sensors[i]->getType() && --sensorNum == 0)
+        {
             return sensors[i];
+        }
     }
     return nullptr;
 }
 
 // deprecated
-Barometer *State::getBaro() { return *baro; }
-GPS *State::getGPS() { return *gps; }
-IMU *State::getIMU() { return *imu; }
+Barometer *State::getBaro() { return baro; }
+GPS *State::getGPS() { return gps; }
+IMU *State::getIMU() { return imu; }
 #pragma endregion
 
 #pragma region Helper Functions
 
-bool State::applySensorType(int i)
+bool State::applySensorType(int i, int sensorNum)
 {
     bool good = true;
     switch (sensors[i]->getType())
     {
     case BAROMETER_:
-        baro = (Barometer **)&sensors[i];
+
+        if (sensorNum == 1)
+            baro = (Barometer *)&sensors[i];
+        // else if (sensorNum == 2)//If you have more than one of the same type, add them like so.
+        //    baro2 = (Barometer *)&sensors[i];
+        else
+            good = false;
         break;
+
     case GPS_:
-        gps = (GPS **)&sensors[i];
+
+        if (sensorNum == 1)
+            gps = (GPS *)&sensors[i];
+        else
+            good = false;
         break;
+
     case IMU_:
-        imu = (IMU **)&sensors[i];
+
+        if (sensorNum == 1)
+            imu = (IMU *)&sensors[i];
+        else
+            good = false;
         break;
+
     default:
         good = false;
         break;
@@ -313,27 +347,34 @@ void State::determineAccelerationMagnitude()
 
 void State::determineStage()
 {
-    if (stageNumber == 0 && (*imu)->getAcceleration().z() > 29 && (*baro)->getRelAltFt() > 30)
+    if (stageNumber == 0 && 
+    (sensorOK(imu) || sensorOK(baro)) && 
+    (sensorOK(imu) ? imu->getAcceleration().z() > 29 : true) && 
+    (sensorOK(baro) ? baro->getRelAltFt() > 30 : true))
+    //if we are in preflight AND
+    //we have either the IMU OR the barometer AND
+    //imu is ok AND the z acceleration is greater than 29 ft/s^2 OR imu is not ok AND
+    //barometer is ok AND the relative altitude is greater than 30 ft OR baro is not ok
+
+    //essentially, if we have either sensor and they meet launch threshold, launch. Otherwise, it will never detect a launch.
     {
-        // digitalWrite(33, HIGH);
         setRecordMode(FLIGHT);
         stageNumber = 1;
         timeOfLaunch = timeAbsolute;
         timePreviousStage = timeAbsolute;
-        strcpy(launchTimeOfDay, (*gps)->getTimeOfDay());
+        strcpy(launchTimeOfDay, gps->getTimeOfDay());
         recordLogData(INFO, "Launch detected.");
         recordLogData(INFO, "Printing static data.");
         for (int i = 0; i < NUM_MAX_SENSORS; i++)
         {
-            if (sensors[i])
+            if (sensorOK(sensors[i]))
             {
                 char logData[200];
                 snprintf(logData, 200, "%s: %s", sensors[i]->getName(), sensors[i]->getStaticDataString());
                 recordLogData(INFO, logData);
             }
         }
-        // digitalWrite(33, LOW);
-    }
+    }//TODO: Add checks for each sensor being ok and decide what to do if they aren't.
     else if (stageNumber == 1 && acceleration.z() < 10)
     {
         stageNumber = 2;
@@ -347,12 +388,12 @@ void State::determineStage()
         stageNumber = 3;
         recordLogData(INFO, "Drogue conditions detected.");
     }
-    else if (stageNumber == 3 && (*baro)->getRelAltFt() < 1000 && timeSinceLaunch > 20) // This should be lowered
+    else if (stageNumber == 3 && baro->getRelAltFt() < 1000 && timeSinceLaunch > 20)
     {
         stageNumber = 4;
         recordLogData(INFO, "Main parachute conditions detected.");
     }
-    else if (stageNumber == 4 && baroVelocity > -1 && (*baro)->getRelAltFt() < 66 && timeSinceLaunch > 25)
+    else if (stageNumber == 4 && baroVelocity > -1 && baro->getRelAltFt() < 66 && timeSinceLaunch > 25)
     {
         stageNumber = 5;
         recordLogData(INFO, "Landing detected. Waiting for 5 seconds to dump data.");
@@ -379,12 +420,9 @@ void State::setCsvString(char *dest, const char *start, int startSize, bool head
     int size = startSize + 1; // includes '\0' at end of string for the end of dataString to use
     for (int i = 0; i < NUM_MAX_SENSORS; i++)
     {
-        if (sensors[i])
+        if (sensorOK(sensors[i]))
         {
-            if (header)
-                str[cursor] = sensors[i]->getCsvHeader();
-            else
-                str[cursor] = sensors[i]->getDataString();
+            str[cursor] = header ? sensors[i]->getCsvHeader() : sensors[i]->getDataString();
             size += strlen(str[cursor++]);
         }
     }
@@ -410,17 +448,24 @@ void State::setCsvString(char *dest, const char *start, int startSize, bool head
     dest[j - 1] = '\0'; // all strings have ',' at end so this gets rid of that and terminates it a character early.
 }
 
+bool State::sensorOK(Sensor *sensor)
+{
+    if (sensor && *sensor)// not nullptr and initialized
+        return true;
+    return false;
+}
+
 #pragma endregion
 
 bool State::transmit()
 {
     char data[200];
-    snprintf(data, 200, "%f,%f,%i,%i,%i,%c,%i,%s", (*gps)->getPos().x(), (*gps)->getPos().y(), (int)(*baro)->getRelAltFt(), (int)baroVelocity, (int)heading_angle, 'H', stageNumber, launchTimeOfDay);
+    snprintf(data, 200, "%f,%f,%i,%i,%i,%c,%i,%s", gps->getPos().x(), gps->getPos().y(), (int)baro->getRelAltFt(), (int)baroVelocity, (int)heading_angle, 'H', stageNumber, launchTimeOfDay);
     bool b = radio->send(data, ENCT_TELEMETRY);
     return b;
 }
 
-void State::initKF(bool useBaro, bool useGps, bool useImu)
+void State::initKF()
 {
     double pr_n = 0.2;
     double init_cov = 2;

--- a/Spaceport/23-24/Code/Teensy-Based Avionics/src/State.cpp
+++ b/Spaceport/23-24/Code/Teensy-Based Avionics/src/State.cpp
@@ -21,6 +21,7 @@ State::State(bool useKalmanFilter, bool stateRecordsOwnFlightData)
     baro = nullptr;
     gps = nullptr;
     imu = nullptr;
+    radio = nullptr;
 
     stateString = nullptr;
     dataString = nullptr;

--- a/Spaceport/23-24/Code/Teensy-Based Avionics/src/State.h
+++ b/Spaceport/23-24/Code/Teensy-Based Avionics/src/State.h
@@ -17,7 +17,7 @@ class State
 public:
     // useKalmanFilter: whether or not to use the Kalman Filter. If false, the state will use the raw sensor data.
     // stateRecordsOwnData: whether or not the state should call recordFlightData() itself. If false, other funcitons must call recordFlightData() to record the state's data.
-    State(bool useKalmanFilter = true, bool stateRecordsOwnData = true);
+    explicit State(bool useKalmanFilter = true, bool stateRecordsOwnData = true);
     ~State();
 
     // to be called after all applicable sensors have been added.

--- a/Spaceport/23-24/Code/Teensy-Based Avionics/src/State.h
+++ b/Spaceport/23-24/Code/Teensy-Based Avionics/src/State.h
@@ -29,11 +29,11 @@ public:
     bool addSensor(Sensor *sensor, int sensorNum = 1);     // add more than one sensor of the same type, and specify which number this one is. 1 indexed. i.e. addSensor(gps, 2) adds the second GPS sensor.
     Sensor *getSensor(SensorType type, int sensorNum = 1); // get a sensor of a certain type. 1 indexed. i.e. getSensor(GPS, 1) gets the first GPS sensor.
 
-    // deprecated to improve flexibility and extendability |
+    // deprecated to improve flexibility and extendability
     Barometer *getBaro(); // |
     GPS *getGPS();        // |
     IMU *getIMU();        // |
-    // deprecated to improve flexibility and extendability |
+    // deprecated to improve flexibility and extendability
 
     Radio *getRadio();
     void setRadio(Radio *r);
@@ -51,7 +51,7 @@ private:
     // example if you have more than one of the same sensor type:
     // constexpr SensorType SENSOR_ORDER[] = {BAROMETER_, BAROMETER_, GPS_, IMU_}; or
     // constexpr SensorType SENSOR_ORDER[] = {BAROMETER_, GPS_, IMU_, BAROMETER_}; It doesn't what order they're in, as long as they're in the array.
-    static constexpr char SENSOR_NAMES[][10] = {"Barometer", "GPS", "IMU"/*, "Barometer 2"*/}; // make this array the same length as NUM_MAX_SENSORS and fill it with the names of the sensors in the same order as SENSOR_ORDER
+    static constexpr char SENSOR_NAMES[][10] = {"Barometer", "GPS", "IMU" /*, "Barometer 2"*/}; // make this array the same length as NUM_MAX_SENSORS and fill it with the names of the sensors in the same order as SENSOR_ORDER
 
     Sensor *sensors[NUM_MAX_SENSORS];
     int numSensors; // how many sensors are actually enabled
@@ -81,7 +81,7 @@ private:
     void determineStage();
     bool applySensorType(int i, int sensorNum); // assigns values to the sensor variables.
     void setCsvString(char *str, const char *start, int startSize, bool header);
-    bool sensorOK(Sensor* sensor);
+    bool sensorOK(Sensor *sensor);
 
     // State variables
     double apogee; // in m above start position

--- a/Spaceport/23-24/Code/Teensy-Based Avionics/src/State.h
+++ b/Spaceport/23-24/Code/Teensy-Based Avionics/src/State.h
@@ -11,49 +11,51 @@
 #include "Radio.h"
 #include "RTC.h"
 #include "RecordData.h"
-
 constexpr char STAGES[][15] = {"Pre-Flight", "Boosting", "Coasting", "Drogue Descent", "Main Descent", "Post-Flight"};
 class State
 {
 public:
-    State(bool useKalmanFilter = true);
+    // useKalmanFilter: whether or not to use the Kalman Filter. If false, the state will use the raw sensor data.
+    // stateRecordsOwnData: whether or not the state should call recordFlightData() itself. If false, other funcitons must call recordFlightData() to record the state's data.
+    State(bool useKalmanFilter = true, bool stateRecordsOwnData = true);
     ~State();
 
     // to be called after all applicable sensors have been added.
-    // Returns false if any sensor failed to init. check for getSensor == nullptr to see which sensor failed. Disables sensor if failed.
-    bool init(bool stateRecordsOwnData = true);
+    // Returns false if any sensor failed to init. check data log for failed sensor. Disables sensor if failed.
+    bool init();
     void updateState();
     int getStageNum();
     // sensor functions
-    bool addSensor(Sensor *sensor);
-    Sensor *getSensor(SensorType type);
-
+    bool addSensor(Sensor *sensor, int sensorNum = 1);     // add more than one sensor of the same type, and specify which number this one is. 1 indexed. i.e. addSensor(gps, 2) adds the second GPS sensor.
+    Sensor *getSensor(SensorType type, int sensorNum = 1); // get a sensor of a certain type. 1 indexed. i.e. getSensor(GPS, 1) gets the first GPS sensor.
 
     // deprecated to improve flexibility and extendability |
-    Barometer *getBaro();                               // |
-    GPS *getGPS();                                      // |
-    IMU *getIMU();                                      // |
+    Barometer *getBaro(); // |
+    GPS *getGPS();        // |
+    IMU *getIMU();        // |
     // deprecated to improve flexibility and extendability |
-  
-  
+
     Radio *getRadio();
     void setRadio(Radio *r);
 
-
     char *getDataString();
     char *getCsvHeader();
-    char *getStateString(); // This contains only the portions that define what the state thinks the rocket looks like. I recommend sending this over the radio during launches.
+    char *getStateString(); // This contains only the portions that define what the state thinks the rocket looks like.
 
     bool transmit();
-    double timeAbsolute;           // in s since uC turned on
+    double timeAbsolute; // in s since uC turned on
 
 private:
-    static constexpr int NUM_MAX_SENSORS = 5; // update with the max number of expected sensors
+    static constexpr int NUM_MAX_SENSORS = 3;                              // update with the max number of expected sensors.
+    static constexpr SensorType SENSOR_ORDER[] = {BAROMETER_, GPS_, IMU_}; // make this array the same length as NUM_MAX_SENSORS and fill it.
+    // example if you have more than one of the same sensor type:
+    // constexpr SensorType SENSOR_ORDER[] = {BAROMETER_, BAROMETER_, GPS_, IMU_}; or
+    // constexpr SensorType SENSOR_ORDER[] = {BAROMETER_, GPS_, IMU_, BAROMETER_}; It doesn't what order they're in, as long as they're in the array.
+    static constexpr char SENSOR_NAMES[][10] = {"Barometer", "GPS", "IMU"/*, "Barometer 2"*/}; // make this array the same length as NUM_MAX_SENSORS and fill it with the names of the sensors in the same order as SENSOR_ORDER
+
     Sensor *sensors[NUM_MAX_SENSORS];
     int numSensors; // how many sensors are actually enabled
 
-    double heading_angle; // in degrees
-    
     char *csvHeader;
     char *dataString;
     char *stateString;
@@ -66,9 +68,9 @@ private:
     void updateSensors();
 
     // Sensor types
-    Barometer **baro;
-    GPS **gps;
-    IMU **imu;
+    Barometer *baro;
+    GPS *gps;
+    IMU *imu;
 
     // internal state variables
     int landingCounter;       // used to save a bit of data after landing
@@ -77,8 +79,9 @@ private:
     // Helper functions
     void determineAccelerationMagnitude();
     void determineStage();
-    bool applySensorType(int index); // points the sensor variables to an appropriate sensors[] index.
-    void setCsvString(char *str, const char* start, int startSize, bool header);
+    bool applySensorType(int i, int sensorNum); // assigns values to the sensor variables.
+    void setCsvString(char *str, const char *start, int startSize, bool header);
+    bool sensorOK(Sensor* sensor);
 
     // State variables
     double apogee; // in m above start position
@@ -94,12 +97,13 @@ private:
     imu::Quaternion orientation;   // in quaternion
     double baroVelocity;           // in m/s
     double baroOldAltitude;        // in m
+    double heading_angle;          // in degrees
 
     char launchTimeOfDay[9];
 
-        //Kalman Filter settings
+    // Kalman Filter settings
     bool useKF;
-    void initKF(bool useBaro, bool useGps, bool useImu);
+    void initKF();
     akf::KFState *kfilter;
     // time pos x y z vel x y z acc x y z
     double *predictions;
@@ -114,12 +118,11 @@ private:
 /*
     To add sensors: Include a local variable for the sensor in the state class and edit the applySensorType() function to point the local variable to the correct index in the sensors[] array.
     Then, edit what the state class does with the sensor data in the updateState() function.
+    Finally, make sure too update the NUM_MAX_SENSORS, SENSOR_ORDER, and SENSOR_NAMES arrays to reflect the new sensor.
 
     It's that easy!
     Don't forget to call addSensor() with your new sensor.
 
-    NOTE: sensors are pointers to sensor pointers. This allows them to be linked to the sensors[] so that changes in there affect the sensor variables.
-    It does make some slightly weird sysntax to use the sensors, but it's not too bad.
-    Instead of if(gps) you use if(*gps) and instead of gps->getPos() you use (*gps)->getPos().
+    Use sensorOK() to check if a sensor is enabled before using it.
 
 */

--- a/Spaceport/23-24/Code/Teensy-Based Avionics/src/State.h
+++ b/Spaceport/23-24/Code/Teensy-Based Avionics/src/State.h
@@ -47,11 +47,11 @@ public:
 
 private:
     static constexpr int NUM_MAX_SENSORS = 3;                              // update with the max number of expected sensors.
-    static constexpr SensorType SENSOR_ORDER[] = {BAROMETER_, GPS_, IMU_}; // make this array the same length as NUM_MAX_SENSORS and fill it.
+    SensorType SENSOR_ORDER[NUM_MAX_SENSORS] = {BAROMETER_, GPS_, IMU_}; // make this array the same length as NUM_MAX_SENSORS and fill it.
     // example if you have more than one of the same sensor type:
     // constexpr SensorType SENSOR_ORDER[] = {BAROMETER_, BAROMETER_, GPS_, IMU_}; or
     // constexpr SensorType SENSOR_ORDER[] = {BAROMETER_, GPS_, IMU_, BAROMETER_}; It doesn't what order they're in, as long as they're in the array.
-    static constexpr char SENSOR_NAMES[][10] = {"Barometer", "GPS", "IMU" /*, "Barometer 2"*/}; // make this array the same length as NUM_MAX_SENSORS and fill it with the names of the sensors in the same order as SENSOR_ORDER
+    const char SENSOR_NAMES[NUM_MAX_SENSORS][10] = {"Barometer", "GPS", "IMU" /*, "Barometer 2"*/}; // make this array the same length as NUM_MAX_SENSORS and fill it with the names of the sensors in the same order as SENSOR_ORDER
 
     Sensor *sensors[NUM_MAX_SENSORS];
     int numSensors; // how many sensors are actually enabled

--- a/Spaceport/23-24/Code/Teensy-Based Avionics/src/State.h
+++ b/Spaceport/23-24/Code/Teensy-Based Avionics/src/State.h
@@ -81,7 +81,7 @@ private:
     void determineStage();
     bool applySensorType(int i, int sensorNum); // assigns values to the sensor variables.
     void setCsvString(char *str, const char *start, int startSize, bool header);
-    bool sensorOK(Sensor *sensor);
+    bool sensorOK(const Sensor *sensor);
 
     // State variables
     double apogee; // in m above start position

--- a/Spaceport/23-24/Code/Teensy-Based Avionics/src/StateTest/FakeBaro.h
+++ b/Spaceport/23-24/Code/Teensy-Based Avionics/src/StateTest/FakeBaro.h
@@ -12,18 +12,18 @@ public:
         temp = ntemp;
         alt = nalt;
     }
-    void *getData() {return &alt; }
-    double getTemp() { return press; }
-    double getPressure() { return temp; }
-    double getRelAltM() { return alt; }
-    bool initialize() { return true; }
+    void *getData() override { return &alt; }
+    double getTemp() override { return press; }
+    double getPressure() override { return temp; }
+    double getRelAltM() override { return alt; }
+    bool initialize() override { return true; }
 
-    const char *getCsvHeader()
+    const char *getCsvHeader() override
     {                                                // incl  B- to indicate Barometer data
         return "B-Pres (hPa),B-Temp (C),B-Alt (m),"; // trailing commas are very important
     }
 
-    char *getDataString()
+    char *getDataString() override
     { // See State.cpp::setDataString() for comments on what these numbers mean
         // float x3
         const int size = 12 * 3 + 3;
@@ -31,19 +31,20 @@ public:
         snprintf(data, size, "%.2f,%.2f,%.2f,", getPressure(), getTemp(), getRelAltM()); // trailing comma
         return data;
     }
-    char *getStaticDataString()
+    char *getStaticDataString() override
     {
         char *data = new char[9];
         snprintf(data, 9, "%s\n", "Testing");
         return data;
     }
 
-    double getTempF(){return 0;}
-    double getRelAltFt() {return 0;}
-    double getPressureAtm() {return 0;}
-    const char *getName() { return "FakeBaro"; }
-    void update() {}
+    double getTempF() override { return 0; }
+    double getRelAltFt() override { return 0; }
+    double getPressureAtm() override { return 0; }
+    const char *getName() override { return "FakeBaro"; }
+    void update() override {}
+
 private:
-    double press, temp, alt;
+    double press = 0, temp = 0, alt = 0;
 };
 #endif

--- a/Spaceport/23-24/Code/Teensy-Based Avionics/src/StateTest/FakeGPS.h
+++ b/Spaceport/23-24/Code/Teensy-Based Avionics/src/StateTest/FakeGPS.h
@@ -9,20 +9,20 @@ class FakeGPS : public GPS
 public:
     void feedData(double pos_x, double pos_y, double pos_z, double h)
     {
-        if(initial_latitude == 0 || initial_longitude == 0){
-            initial_latitude = pos_x;
-            initial_longitude = pos_y;
-            init_alt = pos_z;
+        if(initialLatitude == 0 || initialLongitude == 0){
+            initialLatitude = pos_x;
+            initialLongitude = pos_y;
+            initAltitude = pos_z;
         }
-        pos.x() = (pos_x - initial_latitude) * 111319;
-        pos.y() = (pos_y - initial_longitude) * 111319 * cos(pos_x * 3.14159 / 180);
-        alt = pos_z - init_alt;//hacky way to store initial altitude
+        pos.x() = (pos_x - initialLatitude) * 111319;
+        pos.y() = (pos_y - initialLongitude) * 111319 * cos(pos_x * 3.14159 / 180);
+        alt = pos_z - initAltitude; // hacky way to store initial altitude
         heading = h;
     }
     bool initialize() override { return true; }
-    imu::Vector<2> getPos() { return pos; }
-    double getAlt(){return alt;}
-    imu::Vector<3> getVelocity() {return imu::Vector<3>(0,0,0);}
+    imu::Vector<2> getPos() override { return pos; }
+    double getAlt() override { return alt; }
+    imu::Vector<3> getVelocity() override { return imu::Vector<3>(0, 0, 0); }
 
     double getHeading() override { return heading; }
 
@@ -43,19 +43,18 @@ public:
         return data;
     }
 
-    void *getData() override { return nullptr; }
-    imu::Vector<3> getOriginPos() { return imu::Vector<3>(0, 0, 0); }
-    imu::Vector<3> getDisplace() { return imu::Vector<3>(0, 0, 0); }
-    int getFixQual(){return 6;}
+    imu::Vector<3> getOriginPos() override { return imu::Vector<3>(0, 0, 0); }
+    imu::Vector<3> getDisplace() override { return imu::Vector<3>(0, 0, 0); }
+    int getFixQual() override { return 6; }
     const char *getName() override { return "FakeGPS"; }
     void update() override {}
     char *getTimeOfDay() override { return "00:00:00"; }
 
 private:
-    imu::Vector<2> pos;
-    double alt, heading;
-    double initial_latitude = 0;
-    double initial_longitude = 0;
-    double init_alt = 0;
+    imu::Vector<2> pos = imu::Vector<2>(0, 0);
+    double alt = 0, heading = 0;
+    double initialLatitude = 0;
+    double initialLongitude = 0;
+    double initAltitude = 0;
 };
 #endif

--- a/Spaceport/23-24/Code/Teensy-Based Avionics/src/StateTest/FakeIMU.h
+++ b/Spaceport/23-24/Code/Teensy-Based Avionics/src/StateTest/FakeIMU.h
@@ -18,16 +18,16 @@ public:
         ori.z() = qz;
         ori.w() = qw;
     }
-    bool initialize() { return true; }
-    imu::Quaternion getOrientation() { return ori; }
-    imu::Vector<3> getAcceleration() { return acc; }
+    bool initialize() override { return true; }
+    imu::Quaternion getOrientation() override { return ori; }
+    imu::Vector<3> getAcceleration() override { return acc; }
 
-    const char *getCsvHeader()
+    const char *getCsvHeader() override
     {                                                                                     // incl I- for IMU
         return "I-AX (m/s/s),I-AY (m/s/s),I-AZ (m/s/s),I-QUATX,I-QUATY,I-QUATZ,I-QUATW,"; // trailing comma
     }
 
-    char *getDataString()
+    char *getDataString() override
     {
         const int size = 12 * 7 + 10;
         char *data = new char[size];
@@ -35,22 +35,22 @@ public:
         return data;
     }
 
-    char *getStaticDataString()
+    char *getStaticDataString() override
     {
         char *data = new char[9];
         snprintf(data, 9, "%s\n", "Testing");
         return data;
     }
 
-    imu::Vector<3> getOrientationEuler() { return imu::Vector<3>(0, 0, 0); }
-    imu::Vector<3> getMagnetometer() { return imu::Vector<3>(0, 0, 0); }
-    void *getData() { return nullptr; }
-    const char *getName() { return "FakeIMU"; }
-    void update() {}
+    imu::Vector<3> getOrientationEuler() override { return imu::Vector<3>(0, 0, 0); }
+    imu::Vector<3> getMagnetometer() override { return imu::Vector<3>(0, 0, 0); }
+    void *getData() override { return nullptr; }
+    const char *getName() override { return "FakeIMU"; }
+    void update() override {}
 
 private:
-    imu::Quaternion ori;
-    imu::Vector<3> acc;
+    imu::Quaternion ori = imu::Quaternion(1, 0, 0, 0);
+    imu::Vector<3> acc = imu::Vector<3>(0, 0, 0);
 };
 
 #endif

--- a/Spaceport/23-24/Code/Teensy-Based Avionics/src/main.cpp
+++ b/Spaceport/23-24/Code/Teensy-Based Avionics/src/main.cpp
@@ -14,7 +14,7 @@ DS3231 rtc();               // I2C Address 0x68
 APRSConfig config = {"KC3UTM", "APRS", "WIDE1-1", '[', '/'};
 RadioSettings settings = {433.775, true, false, &hardware_spi, 10, 31, 32};
 RFM69HCW radio = {settings, config};
-State computer;
+State computer;// = useKalmanFilter = true, stateRecordsOwnData = true
 uint32_t radioTimer = millis();
 
 PSRAM *ram;


### PR DESCRIPTION
This one has some other changes as well, but is still relatively minor in scope. It should be tested before merging.
It should also be merged after the other pull request I wrote, #72.

Changes:
- Allows `if(Sensor)` check to see if sensor was initialized. Same as doing `sensor.isInitialized()`
- Neatened state init to bring all flags into constructor instead of init.
- Added `getHasFirstFix()` to gps
- Changed behavior of state sensor storage to support multiple sensors of the same type, found by `(getSensor(SensorType type, optional int sensorNum)` (1 indexed) so the first baro would be `getSensor(BAROMETER_)` and the second barometer would be `getSensor(BAROMETER_, 2)`. The order of sensors is defined by the user when they use `addSensor(SensorType type, optional int sensorNum)` (1 indexed). This will overwrite the first sensor if no number is given, rather than adding on to the end.
- Changed launch detection conditions to verify that at least one of the barometer or IMU is working. Otherwise, it will not detect launch and simply continue printing pre launch to the SD card.